### PR TITLE
Remove link to nowhere from alpha banner

### DIFF
--- a/propertyfrontend/templates/inc_alpha_banner.html
+++ b/propertyfrontend/templates/inc_alpha_banner.html
@@ -2,7 +2,7 @@
   <div class="phase-banner">
     <p>
       <strong class="phase-tag">ALPHA</strong>
-      <span>This is a new service – your <a href="#">feedback</a> will help us to improve it.</span>
+      <span>This is a new service – your feedback will help us to improve it.</span>
     </p>
   </div>
 </div>


### PR DESCRIPTION
See line 14 of https://docs.google.com/a/digital.landregistry.gov.uk/spreadsheets/d/18HH0N0-NRx_zn82sIk2tIGaggcrl9W7-8iLDGNGqEhE/edit#gid=0

Removing link to nowhere.
