### PR TITLE
Add 'view property' link to results

### DIFF
--- a/propertyfrontend/templates/search_results.html
+++ b/propertyfrontend/templates/search_results.html
@@ -36,6 +36,7 @@
                         <div class="grid grid-1-4">
                             <span itemprop="addressLocality">{{ title.property.address.town }}</span><br>
                             <span itemprop="postalCode">{{ title.property.address.postcode }}</span>
+                            <p><a href="/property/{{ title.title_number }}">View property</a></p>
                         </div>
                         <div class="grid grid-1-2">
                             <dl class="definition-tabular">


### PR DESCRIPTION
Land may not have a house number or street address.
We need to decide 'title' elements that would allow the format here: http://style-guide.landregistry.local/modules#search-results
But in the meantime reinstating the 'view property' link.
